### PR TITLE
fix: replace deprecated evalcontextfilter

### DIFF
--- a/jinja2_getenv_extension/__init__.py
+++ b/jinja2_getenv_extension/__init__.py
@@ -1,9 +1,14 @@
 import os
+
 import jinja2
 from jinja2.ext import Extension
 
+try:
+    from jinja2 import pass_eval_context as eval_context
+except ImportError:
+    from jinja2 import evalcontextfilter as eval_context
 
-@jinja2.pass_eval_context
+@eval_context
 def getenv(eval_ctx, value, default=None):
     result = os.environ.get(value, default)
     if result is None:

--- a/jinja2_getenv_extension/__init__.py
+++ b/jinja2_getenv_extension/__init__.py
@@ -3,7 +3,7 @@ import jinja2
 from jinja2.ext import Extension
 
 
-@jinja2.evalcontextfilter
+@jinja2.pass_eval_context
 def getenv(eval_ctx, value, default=None):
     result = os.environ.get(value, default)
     if result is None:


### PR DESCRIPTION
evalcontextfilter is deprecated and will be removed in Jinja 3.1
replace it with pass_eval_context